### PR TITLE
upstream without https:// could not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ git push
 * 在GitHub网站上提交pull request。
 * 定期使用项目仓库内容更新自己仓库内容。
 ```
-$ git remote add upstream github.com/yeasy/docker_practice
+$ git remote add upstream https://github.com/yeasy/docker_practice
 $ git fetch upstream
 $ git checkout master
 $ git rebase upstream/master


### PR DESCRIPTION
I have tried with github.com/yeasy/docker_practice, but occurs 'github.com/yeasy/docker_practice' does not appear to be a git repository" 
