### PR TITLE
Update .bashrc_docker for CentOS usage

### DIFF
--- a/_local/.bashrc_docker
+++ b/_local/.bashrc_docker
@@ -7,11 +7,15 @@ alias docker-ip="sudo docker inspect --format '{{ .NetworkSettings.IPAddress }}'
 
 #the implementation refs from https://github.com/jpetazzo/nsenter/blob/master/docker-enter
 function docker-enter() {
-    if [ -e $(dirname "$0")/nsenter ]; then
+    #if [ -e $(dirname "$0")/nsenter ]; then
+    #Change for centos bash running
+    if [ -e $(dirname '$0')/nsenter ]; then
         # with boot2docker, nsenter is not in the PATH but it is in the same folder
         NSENTER=$(dirname "$0")/nsenter
     else
-        NSENTER=nsenter
+        # if nsenter has already been installed with path notified, here will be clarified
+        NSENTER=$(which nsenter)
+        #NSENTER=nsenter
     fi
     [ -z "$NSENTER" ] && echo "WARN Cannot find nsenter" && return
 


### PR DESCRIPTION
resolve invalid option error and able to find nsenter automatically if it has been installed with path notified