### PR TITLE
Correct supervisor container name

### DIFF
--- a/cases/supervisor.md
+++ b/cases/supervisor.md
@@ -52,7 +52,7 @@ $ sudo docker build -t test/supervisord .
 ```
 启动 supervisor 容器。
 ```
-$ sudo docker run -p 22 -p 80 -t -i test/supervisords
+$ sudo docker run -p 22 -p 80 -t -i test/supervisord
 2013-11-25 18:53:22,312 CRIT Supervisor running as root (no user in config file)
 2013-11-25 18:53:22,312 WARN Included extra file "/etc/supervisor/conf.d/supervisord.conf" during parsing
 2013-11-25 18:53:22,342 INFO supervisord started with pid 1


### PR DESCRIPTION
The name of the container for configured supervisord container is incorrect.
It was: test/supervisords, while in the build step, we tagged it as test/supervisor.