### PR TITLE
Update case/supervisor.md : Resolve apache2 install error

### DIFF
--- a/cases/supervisor.md
+++ b/cases/supervisor.md
@@ -15,6 +15,8 @@ RUN apt-get upgrade -y
 
 ### 安装 ssh、apache 和 supervisor
 ```
+RUN apt-get install -y --force-yes  perl-base=5.14.2-6ubuntu2
+RUN apt-get install -y apache2.2-common
 RUN apt-get install -y openssh-server apache2 supervisor
 RUN mkdir -p /var/run/sshd
 RUN mkdir -p /var/log/supervisor


### PR DESCRIPTION
Resolve error below:


Step 5 : RUN apt-get install -y openssh-server apache2 supervisor
 ---> Running in 816b405cf0d1
Reading package lists...
Building dependency tree...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 apache2 : Depends: apache2-mpm-worker (= 2.2.22-1ubuntu1) but it is not going to be installed or
                    apache2-mpm-prefork (= 2.2.22-1ubuntu1) but it is not going to be installed or
                    apache2-mpm-event (= 2.2.22-1ubuntu1) but it is not going to be installed or
                    apache2-mpm-itk (= 2.2.22-1ubuntu1) but it is not going to be installed
           Depends: apache2.2-common (= 2.2.22-1ubuntu1) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
The command '/bin/sh -c apt-get install -y openssh-server apache2 supervisor' returned a non-zero code: 100