### PR TITLE
修正 compose 例子错误

### DIFF
--- a/compose/usage.md
+++ b/compose/usage.md
@@ -164,8 +164,8 @@ webc:
 haproxy:
     image: haproxy:latest
     volumes:
-        - haproxy:/haproxy-override
-        - haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
+        - ./haproxy:/haproxy-override
+        - ./haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
     links:
         - weba
         - webb


### PR DESCRIPTION
数据卷相对路径必须以 . 或 .. 开头，否则会被认为是卷名称，由于存在 “/” 会提示：ERROR: haproxy/haproxy.cfg includes invalid characters for a local volume name, only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed 

参考来源：https://docs.docker.com/compose/compose-file/
You can mount a relative path on the host, which will expand relative to the directory of the Compose configuration file being used. Relative paths should always begin with . or ...