### PR TITLE
改进'获取镜像'章节

### DIFF
--- a/image/pull.md
+++ b/image/pull.md
@@ -1,39 +1,68 @@
 ## 获取镜像
 
-可以使用 `docker pull` 命令来从仓库获取所需要的镜像。
+之前提到过，[Docker Hub](https://hub.docker.com/explore/) 上有大量的高质量的镜像可以用，这里我们就说一下怎么获取这些镜像并运行。
 
-下面的例子将从 Docker Hub 仓库下载一个 Ubuntu 12.04 操作系统的镜像。
-```
-$ sudo docker pull ubuntu:12.04
-Pulling repository ubuntu
-ab8e2728644c: Pulling dependent layers
-511136ea3c5a: Download complete
-5f0ffaa9455e: Download complete
-a300658979be: Download complete
-904483ae0c30: Download complete
-ffdaafd1ca50: Download complete
-d047ae21eeaf: Download complete
-```
-下载过程中，会输出获取镜像的每一层信息。
+从 Docker Registry 获取镜像的命令是 `docker pull`。其命令格式为：
 
-该命令实际上相当于 `$ sudo docker pull registry.hub.docker.com/ubuntu:12.04` 命令，即从注册服务器 `registry.hub.docker.com` 中的 `ubuntu` 仓库来下载标记为 `12.04` 的镜像。
-
-有时候官方仓库注册服务器下载较慢，可以从其他仓库下载。
-从其它仓库下载时需要指定完整的仓库注册服务器地址。例如
-```
-$ sudo docker pull dl.dockerpool.com:5000/ubuntu:12.04
-Pulling dl.dockerpool.com:5000/ubuntu
-ab8e2728644c: Pulling dependent layers
-511136ea3c5a: Download complete
-5f0ffaa9455e: Download complete
-a300658979be: Download complete
-904483ae0c30: Download complete
-ffdaafd1ca50: Download complete
-d047ae21eeaf: Download complete
+```bash
+docker pull [选项] [Docker Registry地址]<仓库名>:<标签>
 ```
 
-完成后，即可随时使用该镜像了，例如创建一个容器，让其中运行 bash 应用。
+具体的选项可以通过 `docker pull --help` 命令看到，这里我们说一下镜像名称的格式。
+
+* Docker Registry地址：地址的格式一般是 `<域名/IP>[:端口号]`。默认地址是 Docker Hub。
+* 仓库名：如之前所说，这里的仓库名是两段式名称，既 `<用户名>/<软件名>`。对于 Docker Hub，如果不给出用户名，则默认为 `library`，也就是官方镜像。
+
+比如：
+
+```bash
+$ docker pull ubuntu:14.04
+14.04: Pulling from library/ubuntu
+bf5d46315322: Pull complete
+9f13e0ac480c: Pull complete
+e8988b5b3097: Pull complete
+40af181810e7: Pull complete
+e6f7c7e5c03e: Pull complete
+Digest: sha256:147913621d9cdea08853f6ba9116c2e27a3ceffecf3b492983ae97c3d643fbbe
+Status: Downloaded newer image for ubuntu:14.04
 ```
-$ sudo docker run -t -i ubuntu:12.04 /bin/bash
-root@fe7fc4bd8fc9:/#
+
+上面的命令中没有给出 Docker Registry 地址，因此将会从 Docker Hub 获取镜像。而镜像名称是 `ubuntu:14.04`，因此将会获取官方镜像 `library/ubuntu` 仓库中标签为 `14.04` 的镜像。
+
+从下载过程中可以看到我们之前提及的分层存储的概念，镜像是由多层存储所构成。下载也是一层层的去下载，并非单一文件。下载过程中给出了每一层的 ID 的前 12 位。并且下载结束后，给出该镜像完整的 `sha256` 的签名，以确保下载一致性。
+
+在实验上面命令的时候，你可能会发现，你所看到的层 ID 以及 `sha256` 的签名和这里的不一样。这是因为官方镜像是一直在维护的，有任何新的 bug，或者版本更新，都会进行修复再以原来的标签发布，这样可以确保任何使用这个标签的用户可以获得更安全、更稳定的镜像。
+
+*如果从 Docker Hub 下载镜像非常缓慢，很可能是由于伟大的墙所致，参照前面的章节配置加速器。*
+
+### 运行
+
+有了镜像后，我们就可以以这个镜像为基础启动一个容器来运行。以上面的 `ubuntu:14.04` 为例，如果我们打算启动里面的 `bash` 并且进行交互式操作的话，可以执行下面的命令。
+
+```bash
+$ docker run -it --rm ubuntu:14.04 bash
+root@e7009c6ce357:/# cat /etc/os-release
+NAME="Ubuntu"
+VERSION="14.04.5 LTS, Trusty Tahr"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 14.04.5 LTS"
+VERSION_ID="14.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
+root@e7009c6ce357:/# exit
+exit
+$
 ```
+
+`docker run` 就是运行容器的命令，具体格式我们会在后面的章节讲解，我们这里简要的说明一下上面用到的参数。
+
+* `-it`：这是两个参数，一个是 `-i`：交互式操作，一个是 `-t` 终端。我们这里打算进入 `bash` 执行一些命令并查看返回结果，因此我们需要交互式终端。
+* `--rm`：这个参数是说容器退出后随之将其删除。默认情况下，为了排障需求，退出的容器并不会立即删除，除非手动 `docker rm`。我们这里只是随便执行个命令，看看结果，不需要排障和保留结果，因此使用 `--rm` 可以避免浪费空间。
+* `ubuntu:14.04`：这是指用 `ubuntu:14.04` 镜像为基础来启动容器。
+* `bash`：放在镜像名后的是**命令**，这里我们希望有个交互式 Shell，因此用的是 `bash`。
+
+进入容器后，我们可以在 Shell 下操作，执行任何所需的命令。这里，我们执行了 `cat /etc/os-release`，这是 Linux 常用的查看当前系统版本的命令，从返回的结果可以看到容器内是 `Ubuntu 14.04.5 LTS` 系统。
+
+最后我们通过 `exit` 退出了这个容器。


### PR DESCRIPTION
修正一些表达，以及扩展更多信息。
关于下载缓慢的问题，改为推荐使用加速器，这样可以始终保持使用官方维护的新版本。因此在前面的安装章节将来需要补充一些安装配置的内容，包括加速器的设置。