### PR TITLE
doc(compose_file): fix version number of secrets

### DIFF
--- a/compose/compose_file.md
+++ b/compose/compose_file.md
@@ -394,7 +394,7 @@ ports:
 存储敏感数据，例如 `mysql` 服务密码。
 
 ```bash
-version: "3"
+version: "3.1"
 services:
 
 mysql:

--- a/compose/compose_file.md
+++ b/compose/compose_file.md
@@ -393,7 +393,7 @@ ports:
 
 存储敏感数据，例如 `mysql` 服务密码。
 
-```bash
+```yaml
 version: "3.1"
 services:
 


### PR DESCRIPTION
使用 secrets 最低版本为 3.1

### Proposed changes (Mandatory)

使用 secrets 最低版本为 3.1

使用 `version = "3" ` 报错 ：`docker-compose config
ERROR: The Compose file './docker-compose.yml' is invalid because:
Invalid top-level property "secrets". Valid top-level sections for this Compose file are: version, services, networks, volumes, and extensions startingwith "x-".`

官网示例：

```yml
version: "3.1"
services:
  redis:
    image: redis:latest
    deploy:
      replicas: 1
    secrets:
      - my_secret
      - my_other_secret
secrets:
  my_secret:
    file: ./my_secret.txt
  my_other_secret:
    external: true
```
https://docs.docker.com/compose/compose-file/#short-syntax-2

### Fix issues (Optional)

<!--
    Tell us what issues you fixed, e.g., fix #123 
-->
