### PR TITLE
fix ubuntu16.04 path of bash ##342

### DIFF
--- a/image/pull.md
+++ b/image/pull.md
@@ -42,7 +42,7 @@ Status: Downloaded newer image for ubuntu:16.04
 ```bash
 $ docker run -it --rm \
     ubuntu:16.04 \
-    bash
+    bin/bash
 
 root@e7009c6ce357:/# cat /etc/os-release
 NAME="Ubuntu"


### PR DESCRIPTION
<!--
    Thanks for your contribution. 
    See [CONTRIBUTING](CONTRIBUTING.md) for contribution guidelines.
-->

### Proposed changes (Mandatory)


    Tell us what you did and why: 
ubuntu16.04 中 bash 路径为/bin/bash 
书中路径为/bash 导致
`
docker: Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "exec: \"/bash\": stat /bash: no such file or directory": unknown.
`
    One line short description
    修改image/pull.md 文件中 /bash 为  /bin/bash
![image](https://user-images.githubusercontent.com/19340899/40852446-0f36212e-65fd-11e8-89c7-57fcb1db789b.png)


### Fix issues (Optional)


    Tell us what issues you fixed, 
 fix #342 

