### PR TITLE
Update mirror.md

### DIFF
--- a/install/mirror.md
+++ b/install/mirror.md
@@ -24,7 +24,7 @@ $ sudo service docker restart
 
 ### Ubuntu 16.04+、Debian 8+、CentOS 7
 
-对于使用 [systemd](https://www.freedesktop.org/wiki/Software/systemd/) 的系统，请在 `/etc/docker/daemon.json` 中写入如下内容（如果文件不存在请新建该文件）
+对于使用 [systemd](https://www.freedesktop.org/wiki/Software/systemd/) 的系统，请在 `/etc/docker/daemon.conf` 中写入如下内容（如果文件不存在请新建该文件）
 
 ```json
 {


### PR DESCRIPTION
`.json` 的配置文件后缀名会导致 docker 无法访问重启，修改后缀为 `.conf` 则能正常重启

<!--
    Thanks for your contribution. 
    See [CONTRIBUTING](CONTRIBUTING.md) for contribution guidelines.
-->

### Proposed changes (Mandatory)

<!--
    Tell us what you did and why: 

    One line short description
    
    And details in other paragraphs.
-->

### Fix issues (Optional)

<!--
    Tell us what issues you fixed, e.g., fix #123 
-->
