### PR TITLE
image/rm.md: introduce overlay2

### DIFF
--- a/image/rm.md
+++ b/image/rm.md
@@ -95,3 +95,5 @@ $ docker image rm $(docker image ls -q -f before=mongo:3.2)
 所以对于 CentOS/RHEL 的用户来说，在没有办法使用 `UnionFS` 的情况下，一定要配置 `direct-lvm` 给 `devicemapper`，无论是为了性能、稳定性还是空间利用率。
 
 *或许有人注意到了 CentOS 7 中存在被 backports 回来的 `overlay` 驱动，不过 CentOS 里的这个驱动达不到生产环境使用的稳定程度，所以不推荐使用。*
+
+但是，在高版本的docker-ce中，可以通过在daemon.json中设置`overlay2.override_kernel_check`为true来使用`overlay2`, 可参考[文档](https://docs.docker.com/storage/storagedriver/overlayfs-driver)。


### PR DESCRIPTION
目前的docker-ce17以上，在CentOS环境上，可以使用overlay2存储，且性能等方面都可以用作生产。