### PR TITLE
Update stop cmd

### DIFF
--- a/appendix/faq/README.md
+++ b/appendix/faq/README.md
@@ -44,7 +44,7 @@
 
 ### 如何停止所有正在运行的容器？
 
-答：可以使用 `docker kill $(docker container ls -q)` 命令。
+答：可以使用 `docker stop $(docker container ls -q)` 命令。
 
 ### 如何批量清理已经停止的容器？
 


### PR DESCRIPTION
`docker stop` send SIGTERM, and then SIGKILL after grace period,
while `docker kill` send SIGTERM directly,
so `docker stop` is more safe and ensure the integrity of the data.

Signed-off-by: daixiang0 <764524258@qq.com>