### PR TITLE
Update centos.md

### DIFF
--- a/appendix/repo/centos.md
+++ b/appendix/repo/centos.md
@@ -4,7 +4,7 @@
 
 [CentOS](https://en.wikipedia.org/wiki/CentOS) 是流行的 Linux 发行版，其软件包大多跟 RedHat 系列保持一致。
 
-该仓库位于 `https://hub.docker.com/_/centos` ，提供了 CentOS 从 5 ~ 7 各个版本的镜像。
+该仓库位于 `https://hub.docker.com/_/centos` ，提供了 CentOS 从 5 ~ 8 各个版本的镜像。
 
 ### 使用方法
 


### PR DESCRIPTION
### docker hub上已经有CentOS8版本，所以
---
#### 文章链接：https://yeasy.gitbooks.io/docker_practice/content/appendix/repo/centos.html
**将这句话  `提供了 CentOS 从 5 ~ 7 各个版本的镜像` 改为  `提供了 CentOS 从 5 ~ 8 各个版本的镜像`**

---
 :yum: