### PR TITLE
Fix USTC mirror at CentOS and Fedora.

### DIFF
--- a/install/centos.md
+++ b/install/centos.md
@@ -43,6 +43,7 @@ $ sudo yum install -y yum-utils \
 $ sudo yum-config-manager \
     --add-repo \
     https://mirrors.ustc.edu.cn/docker-ce/linux/centos/docker-ce.repo
+$ sudo sed -i 's/download.docker.com/mirrors.ustc.edu.cn\/docker-ce/g' /etc/yum.repos.d/docker-ce.repo
 
 
 # 官方源


### PR DESCRIPTION
### Proposed changes (Mandatory)

Added command to replace `download.docker.com` with `mirrors.ustc.edu.cn/docker-ce`.

In addition, since I am not a Fedora user, I need someone using Fedora to help add the same command at https://github.com/yeasy/docker_practice/blob/master/install/fedora.md.

### Fix issues (Optional)

Fix issue #440 
