### PR TITLE
Update secret.md

### DIFF
--- a/swarm_mode/secret.md
+++ b/swarm_mode/secret.md
@@ -62,7 +62,7 @@ $ docker service create \
      --network mysql_private \
      --publish target=30000,port=80 \
      --mount type=volume,source=wpdata,destination=/var/www/html \
-     --secret source=mysql_password,target=wp_db_password,mode=0400 \
+     --secret source=mysql_password,target=wp_db_password,mode=0444 \
      -e WORDPRESS_DB_USER="wordpress" \
      -e WORDPRESS_DB_PASSWORD_FILE="/run/secrets/wp_db_password" \
      -e WORDPRESS_DB_HOST="mysql:3306" \


### PR DESCRIPTION
apache工作进程是www-data用户运行，而密钥文件（/run/secrets/wp_db_password）的属主是root，导致apache工作进程无法读取密钥，从而无法连接数据库

<!--
    Thanks for your contribution.
    See [CONTRIBUTING](CONTRIBUTING.md) for contribution guidelines.
-->

**Proposed changes (Mandatory)**

<!--
    Tell us what you did and why:

    One line short description

    And details in other paragraphs.
-->

**Fix issues (Optional)**

<!--
    Tell us what issues you fixed, e.g., fix #123
-->
