### PR TITLE
fix: wrong key of registry mirrors

### DIFF
--- a/repository/registry.md
+++ b/repository/registry.md
@@ -103,7 +103,7 @@ REPOSITORY                         TAG                 IMAGE ID            CREAT
 
 ```json
 {
-  "registry-mirror": [
+  "registry-mirrors": [
     "https://hub-mirror.c.163.com",
     "https://mirror.baidubce.com"
   ],


### PR DESCRIPTION
<!--
    Thanks for your contribution.
    See [CONTRIBUTING](CONTRIBUTING.md) for contribution guidelines.
-->

**Proposed changes (Mandatory)**
Key of registry mirrors should be `registry-mirrors` instead of `registry-mirror`

<!--
    Tell us what you did and why:

    One line short description

    And details in other paragraphs.
-->

**Fix issues (Optional)**

<!--
    Tell us what issues you fixed, e.g., fix #123
-->
