### PR TITLE
修复离线rpm包安装方式，解决各个rpm包先后依赖安装顺序不一致导致安装失败的问题。

### DIFF
--- a/install/offline.md
+++ b/install/offline.md
@@ -79,8 +79,9 @@ exiting because "Download Only" specified
 ```
 #### 复制到目标服务器之后进入文件夹安装(C-N)
 
+* 离线安装时，必须使用rpm命令不检查依赖的方式安装
 ```bash
-yum install *.rpm
+rpm -Uvh *.rpm --nodeps --force
 ```
 
 #### 锁定软件版本(C-N)


### PR DESCRIPTION
修复离线rpm包安装方式，解决各个rpm包先后依赖安装顺序不一致导致安装失败的问题。

* “yum install *.rpm“的安装方式，因为rpm包有复杂的依赖关系，安装时因为当前正在安装的包的依赖包没有安装导致当前包安装失败。
* 使用rpm -Uvh的方式，可以依次安装各个rpm包，全部安装成功后再检查依赖是否正确。