### PR TITLE
fix: 修复 Star History 图表无法显示

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ mdpress serve
 ## Star History
 
 <p align="center">
-  <a href="https://star-history.com/#yeasy/docker_practice&Date">
-    <img src="https://api.star-history.com/svg?repos=yeasy/docker_practice&type=Date" alt="Star History Chart">
+  <a href="https://star-history.dera.page/#yeasy/docker_practice&Date">
+    <img src="https://star-history.dera.page/svg?repos=yeasy/docker_practice&type=Date" alt="Star History Chart">
   </a>
 </p>
 


### PR DESCRIPTION
当前 README 里的 Star History 图表因 GitHub stargazer API 限制而无法显示，请尽快修复。

已改用备用数据源，无需任何 API 令牌即可正常工作。